### PR TITLE
Optuna update

### DIFF
--- a/SURFGAN_3D/optuna_objective.py
+++ b/SURFGAN_3D/optuna_objective.py
@@ -357,10 +357,10 @@ def optuna_objective(trial, args, config):
                 #sess = tf_debug.TensorBoardDebugWrapperSession(sess, 'localhost:6789')
                 
                 # Measure speed as often as small_summaries, but one iteration later. This avoids timing the summaries themselves.
-                speed_measurement_bool = ((local_step - 1) % args.summary_small_every_nsteps == 0)
-                small_summary_bool = (local_step % args.summary_small_every_nsteps == 0)
-                large_summary_bool = (local_step % args.summary_large_every_nsteps == 0)
-                metrics_summary_bool = (local_step % args.metrics_every_nsteps == 0)
+                speed_measurement_bool = ((local_step - 1) % args.summary_small_every_nsteps < batch_size)
+                small_summary_bool = (local_step % args.summary_small_every_nsteps < batch_size)
+                large_summary_bool = (local_step % args.summary_large_every_nsteps < batch_size)
+                metrics_summary_bool = (local_step % args.metrics_every_nsteps < batch_size)
 
                 # Run training step, including summaries
                 if large_summary_bool:
@@ -384,7 +384,7 @@ def optuna_objective(trial, args, config):
 
                 #print("Completed step")
                 global_step += batch_size * global_size
-                local_step += 1
+                local_step += batch_size
 
                 end = time.time()
                 local_img_s = batch_size / (end - start)
@@ -430,12 +430,14 @@ def optuna_objective(trial, args, config):
 
                 if verbose:
                     if large_summary_bool:
-                        print('Writing large summary...')
+                        if not hyperparam_opt_inter_trial:
+                            print('Writing large summary...')
                         writer.add_summary(summary_s, global_step)
                         writer.add_summary(summary_s_val, global_step)
                         writer.add_summary(summary_l, global_step)
                     elif small_summary_bool:
-                        print('Writing small summary...')
+                        if not hyperparam_opt_inter_trial:
+                            print('Writing small summary...')
                         writer.add_summary(summary_s, global_step)
                         writer.add_summary(summary_s_val, global_step)
                     elif speed_measurement_bool:

--- a/SURFGAN_3D/optuna_suggestions.py
+++ b/SURFGAN_3D/optuna_suggestions.py
@@ -57,9 +57,9 @@ def optuna_override_undefined(args, trial):
         if verbose:
             print(f"args.g_lr_increase = {args.g_lr_increase} (from: optuna trial)")
             print(f"args.g_lr_rise_niter = {args.g_lr_rise_niter} (from: optuna trial)")
-    elif (args.g_lr_increase is not None and args.g_lr_rise_niter is None) or (args.g_lr_rise_niter is not None and args.g_lr_increase is None):
+    elif (args.g_lr_increase is not None and args.g_lr_rise_niter is None):
         if verbose:
-            print("ERROR: either both g_lr_increase and g_lr_rise_niter have to be specified, or neither. You cannot specify only one.")
+            print("ERROR: if you specify g_lr_increase on the command line, g_lr_rise_niter also has to be specified.")
         raise NotImplementedError()
     elif verbose:
         print(f"args.g_lr_increase = {args.g_lr_increase} (from: command line argument)")
@@ -72,9 +72,9 @@ def optuna_override_undefined(args, trial):
         if verbose:
             print(f"args.g_lr_decrease = {args.g_lr_decrease} (from: optuna trial)")
             print(f"args.g_lr_decay_niter = {args.g_lr_decay_niter} (from: optuna trial)")
-    elif (args.g_lr_decrease is not None and args.g_lr_decay_niter is None) or (args.g_lr_decay_niter is not None and args.g_lr_decrease is None):
+    elif (args.g_lr_decrease is not None and args.g_lr_decay_niter is None):
         if verbose:
-            print("ERROR: either both g_lr_decrease and g_lr_decay_niter have to be specified, or neither. You cannot specify only one.")
+            print("ERROR: if you specify g_lr_decrease on the command line, g_lr_decay_niter also has to be specified.")
         raise NotImplementedError()
     elif verbose:
         print(f"args.g_lr_decrease = {args.g_lr_decrease} (from: command line argument)")
@@ -87,9 +87,9 @@ def optuna_override_undefined(args, trial):
         if verbose:
             print(f"args.d_lr_increase = {args.d_lr_increase} (from: optuna trial)")
             print(f"args.d_lr_rise_niter = {args.d_lr_rise_niter} (from: optuna trial)")
-    elif (args.d_lr_increase is not None and args.d_lr_rise_niter is None) or (args.d_lr_rise_niter is not None and args.d_lr_increase is None):
+    elif (args.d_lr_increase is not None and args.d_lr_rise_niter is None):
         if verbose:
-            print("ERROR: either both d_lr_increase and d_lr_rise_niter have to be specified, or neither. You cannot specify only one.")
+            print("ERROR: if you specify d_lr_increase on the command line, d_lr_rise_niter also has to be specified.")
         raise NotImplementedError()
     elif verbose:
         print(f"args.d_lr_increase = {args.d_lr_increase} (from: command line argument)")
@@ -102,9 +102,9 @@ def optuna_override_undefined(args, trial):
         if verbose:
             print(f"args.d_lr_decrease = {args.d_lr_decrease} (from: optuna trial)")
             print(f"args.d_lr_decay_niter = {args.d_lr_decay_niter} (from: optuna trial)")
-    elif (args.d_lr_decrease is not None and args.d_lr_decay_niter is None) or (args.d_lr_decay_niter is not None and args.d_lr_decrease is None):
+    elif (args.d_lr_decrease is not None and args.d_lr_decay_niter is None):
         if verbose:
-            print("ERROR: either both d_lr_decrease and d_lr_decay_niter have to be specified, or neither. You cannot specify only one.")
+            print("ERROR: if you specify d_lr_decrease on the command line, d_lr_decay_niter also has to be specified.")
         raise NotImplementedError()
     elif verbose:
         print(f"args.d_lr_decrease = {args.d_lr_decrease} (from: command line argument)")

--- a/SURFGAN_3D/optuna_suggestions.py
+++ b/SURFGAN_3D/optuna_suggestions.py
@@ -36,14 +36,14 @@ def optuna_override_undefined(args, trial):
         print(f"args.base_batch_size = {args.base_batch_size} (from: command line argument)")
 
     if not args.g_lr:
-        args.g_lr = trial.suggest_loguniform('generator_LR', 1e-6, 1e-2)
+        args.g_lr = trial.suggest_loguniform('generator_LR', 1e-4, 1e-1)
         if verbose:
             print(f"args.g_lr = {args.g_lr} (from: optuna trial)")
     elif verbose:
         print(f"args.g_lr = {args.g_lr} (from: command line argument)")
 
     if not args.d_lr:
-        args.d_lr = trial.suggest_loguniform('discriminator_LR', 1e-6, 1e-2)
+        args.d_lr = trial.suggest_loguniform('discriminator_LR', 1e-4, 1e-1)
         if verbose:
             print(f"args.d_lr = {args.d_lr} (from: optuna trial)")
     elif verbose:

--- a/SURFGAN_3D/utils.py
+++ b/SURFGAN_3D/utils.py
@@ -9,6 +9,21 @@ import time
 
 from dataset import NumpyPathDataset
 
+def print_study_summary(study):
+    """Prints a summary of the Optuna study.
+    Parameters:
+        study: an optuna study
+    Returns:
+        None
+    """
+    print("Number of finished trials: ", len(study.trials))
+    print("Best trial:")
+    trial = study.best_trial
+    print(" Value: ", trial.value)
+    print(" Params: ")
+    for key, value in trial.params.items():
+        print("    {}: {}".format(key, value))
+        
 def dump_weight_for_debugging(sess):
     """Dumps the first weight from the dense layer. Can be used for debugging, e.g. to see how it develops, or if it gets loaded correctly from a checkpoint.
     Parameters:


### PR DESCRIPTION
Reorganized how the program runs. Essentially, there are four modes:

- a single training
- a single training continued from the best set of hyperparameters in an optuna study
- hyperparameter tuning with optuna with inter-trial parallelism (one worker per trial)
- hyperparameter tuning with optuna with intra-trial parallelism (all MPI workers work on a single trial).

Allow specifying optuna pruner on command line.