### PR TITLE
Save metrics parallel

### DIFF
--- a/SURFGAN_3D/metrics/save_metrics.py
+++ b/SURFGAN_3D/metrics/save_metrics.py
@@ -89,8 +89,7 @@ def save_metrics(writer, sess, npy_data, gen_sample, batch_size, global_size, gl
         # If using horovod: get batches with batch_mpi, which distributes samples from rank 0.
         # Allows e.g. to compute the metrics on the full validation set, i.e. seeing each image (exactly) once.
         if horovod:
-            real_batch = npy_data.batch_mpi(batch_size, True, True)
-            print(f'Worker: {hvd.rank()}. Metrics local batch size: {len(real_batch)}. Counter: {counter}')
+            real_batch = npy_data.batch_mpi(batch_size)
         else:
             real_batch = npy_data.batch(batch_size)
         real_batch = data.normalize_numpy(real_batch, data_mean, data_stddev, verbose)

--- a/SURFGAN_3D/optuna_objective.py
+++ b/SURFGAN_3D/optuna_objective.py
@@ -486,32 +486,35 @@ def optuna_objective(trial, args, config):
             # Final metric computation is not parallelized, because we want it to be computed on all samples from the test set, without duplicates.
             # Since the sampling is random for each worker, doing this with all workers could result in some samples being seen by multiple times, with others not being seen at all.
             # Set horovod to False explicitely, otherwise rank 0 will wait forever for a response from the other ranks.
-            print(f"Computing final metrics for phase {phase} ...")
+            if verbose:
+                print(f"Computing final metrics for phase {phase} ...")
             sess.run(assign_ema_weights)
             if args.compute_metrics_test:
                 start_metrics_test = time.time()
                 metrics_test = save_metrics(None, sess, npy_data_test, gen_sample, args.metrics_batch_size, global_size, global_step, get_xy_dim(phase, args.start_shape), args.horovod, get_compute_metrics_dict(args), len(npy_data_test), args.data_mean, args.data_stddev, verbose)
                 end_metrics_test = time.time()
-                print(f"Computing metrics on test set took {end_metrics_test - start_metrics_test} seconds")
-                print("Test dataset metrics:")
-                print(metrics_test)
+                if verbose:
+                    print(f"Computing metrics on test set took {end_metrics_test - start_metrics_test} seconds")
+                    print("Test dataset metrics:")
+                    print(metrics_test)
             if args.compute_metrics_validation:
                 start_metrics_val = time.time()
                 metrics_val = save_metrics(None, sess, npy_data_validation, gen_sample, args.metrics_batch_size, global_size, global_step, get_xy_dim(phase, args.start_shape), args.horovod, get_compute_metrics_dict(args), len(npy_data_validation), args.data_mean, args.data_stddev, verbose)
-                
                 end_metrics_val = time.time()
-                print(f"Computing metrics on validation set took {end_metrics_val - start_metrics_val} seconds")
-                print("Validation dataset metrics:")
-                print(metrics_val)
+                if verbose:
+                    print(f"Computing metrics on validation set took {end_metrics_val - start_metrics_val} seconds")
+                    print("Validation dataset metrics:")
+                    print(metrics_val)
                 # Overwrite the last fid
                 last_fid = metrics_val['FID']
             if args.compute_metrics_train:
                 start_metrics_train = time.time()
                 metrics_train = save_metrics(None, sess, npy_data_train, gen_sample, args.metrics_batch_size, global_size, global_step, get_xy_dim(phase, args.start_shape), args.horovod, get_compute_metrics_dict(args), len(npy_data_train), args.data_mean, args.data_stddev, verbose)
                 end_metrics_train = time.time()
-                print(f"Computing metrics on training set took {end_metrics_train - start_metrics_train} seconds")
-                print("Training dataset metrics:")
-                print(metrics_train)
+                if verbose:
+                    print(f"Computing metrics on training set took {end_metrics_train - start_metrics_train} seconds")
+                    print("Training dataset metrics:")
+                    print(metrics_train)
             sess.run(restore_original_weights)
                 
             if trial is not None:


### PR DESCRIPTION
Less verbosity (remove 'debugging' verbosity from the NumpyPathDataset whenever batch_mpi is called, and remove duplicate verbosity from rank 1 and up)